### PR TITLE
Adds maximum dependency on selenium grid version

### DIFF
--- a/selenium-grid-parser.gemspec
+++ b/selenium-grid-parser.gemspec
@@ -22,4 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "nokogiri", "~> 1.6"
   spec.add_development_dependency "httparty", "~> 0.13"
+  spec.add_development_dependency "selenium-webdriver", "~> 3.6.0"
+
+  spec.add_runtime_dependency "selenium-webdriver", " >= 3.4.0", "< 3.7.0"
 end


### PR DESCRIPTION
The grid console parser can go as high as selenium grid and selenium-webdriver version 3.6.0 before breaking. 